### PR TITLE
Fix tools/install_roles.sh to work in zuul

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,5 @@
 ---
 - src: geerlingguy.repo-epel
 
-- src: https://github.com/ansible-security/ids_install.git
+- src: git+https://github.com/ansible-security/ids_install
   name: ids_install

--- a/tools/install_roles.sh
+++ b/tools/install_roles.sh
@@ -17,7 +17,9 @@ TOOLSDIR=$(dirname $0)
 
 # NOTE(pabelanger): Check if we are running in the gate, if so use cached repos
 # to avoid hitting the network.
-if [ -f /etc/ci/mirror_info.sh ]; then
+if [ -d /etc/dib-manifests/ ]; then
+    # TODO(pabelanger): Have molecule support existing shell variables.
+    HOME=${HOME:-/home/zuul}
     sed -e "s|https://|file://${HOME}/src/|g" -i $TOOLSDIR/../requirements.yml
 fi
 


### PR DESCRIPTION
The previous wasn't testing properly, and exposed some issue with cross project testing. This is fixe now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>